### PR TITLE
Implementation of node repeater until failure and automated AddCustomType() clean up

### DIFF
--- a/addons/burttree/BurtTreePlugin.cs
+++ b/addons/burttree/BurtTreePlugin.cs
@@ -1,50 +1,37 @@
 #if TOOLS
 using Godot;
+using System.Collections.Generic;
 
 [Tool]
 public partial class BurtTreePlugin : EditorPlugin
 {
-    public override void _EnterTree()
-    {
-        // Tree Node
-        Texture2D treeIcon = GD.Load<Texture2D>("res://addons/burttree/icons/node-tree.png");
-        Script treeScript = GD.Load<Script>("res://addons/burttree/scripts/Tree.cs");
-        AddCustomType("BurtTree", "Node", treeScript, treeIcon);
+	List<string> registeredTypesList = new List<string>();
 
-        // Action Node
-        Texture2D actionIcon = GD.Load<Texture2D>("res://addons/burttree/icons/node-action.png");
-        Script actionScript = GD.Load<Script>("res://addons/burttree/scripts/ActionNode.cs");
-        AddCustomType("BurtTreeActionNode", "Node", actionScript, actionIcon);
+	public override void _EnterTree()
+	{
+		var registerCustomType = (string name, string script, string icon) =>
+		{
+			AddCustomType(
+				name, "Node",
+				GD.Load<Script>($"res://addons/burttree/scripts/{script}.cs"),
+				GD.Load<Texture2D>($"res://addons/burttree/icons/{icon}.png")
+			);
+			registeredTypesList.Add(name);
+		};
 
-        // Selector Node
-        Texture2D selectorIcon = GD.Load<Texture2D>("res://addons/burttree/icons/node-selector.png");
-        Script selectorScript = GD.Load<Script>("res://addons/burttree/scripts/Selector.cs");
-        AddCustomType("BurtTreeSelectorNode", "Node", selectorScript, selectorIcon);
+		registerCustomType("BurtTree", "Tree", "node-tree");
+		registerCustomType("BurtTreeActionNode", "ActionNode", "node-action");
+		registerCustomType("BurtTreeSelectorNode", "Selector", "node-selector");
+		registerCustomType("BurtTreeSequenceNode", "Sequence", "node-sequence");
+		registerCustomType("BurtTreeInverterNode", "Inverter", "node-inverter");
+		registerCustomType("BurtTreeRepeaterNode", "Repeater", "node-repeater");
+		registerCustomType("BurtTreeRepeaterUntilFailureNode", "RepeaterUntilFailure", "node-repeater");
+	}
 
-        // Sequence Node
-        Texture2D sequenceIcon = GD.Load<Texture2D>("res://addons/burttree/icons/node-sequence.png");
-        Script sequenceScript = GD.Load<Script>("res://addons/burttree/scripts/Sequence.cs");
-        AddCustomType("BurtTreeSequenceNode", "Node", sequenceScript, sequenceIcon);
-
-        // Inverter Node
-        Texture2D inverterIcon = GD.Load<Texture2D>("res://addons/burttree/icons/node-inverter.png");
-        Script inverterScript = GD.Load<Script>("res://addons/burttree/scripts/Inverter.cs");
-        AddCustomType("BurtTreeInverterNode", "Node", inverterScript, inverterIcon);
-
-        // Repeater Node
-        Texture2D repeaterIcon = GD.Load<Texture2D>("res://addons/burttree/icons/node-repeater.png");
-        Script repeaterScript = GD.Load<Script>("res://addons/burttree/scripts/Repeater.cs");
-        AddCustomType("BurtTreeRepeaterNode", "Node", repeaterScript, repeaterIcon);
-    }
-
-    public override void _ExitTree()
-    {
-        RemoveCustomType("BurtTree");
-        RemoveCustomType("Action");
-        RemoveCustomType("Selector");
-        RemoveCustomType("Sequence");
-        RemoveCustomType("Inverter");
-        RemoveCustomType("Repeater");
-    }
+	public override void _ExitTree()
+	{
+		foreach (var name in registeredTypesList)
+			RemoveCustomType(name);
+	}
 }
 #endif

--- a/addons/burttree/scripts/RepeaterUntilFailure.cs
+++ b/addons/burttree/scripts/RepeaterUntilFailure.cs
@@ -1,0 +1,43 @@
+using Godot;
+using System;
+
+namespace BurtTree
+{
+	[Icon("res://addons/burttree/icons/node-repeater.png")]
+	public partial class RepeaterUntilFailure : DecoratorNode
+	{
+		[Export] public int MaxRepeats { get; set; } = -1;
+
+		private int _repeatCount = 0;
+
+		public override NodeState Execute()
+		{
+			if (Child == null)
+			{
+				GD.PrintErr("RepeaterUntilFailure must have a child node.");
+				return NodeState.Failure;
+			}
+
+			NodeState result = Child.Execute();
+
+            if (result == NodeState.Failure)
+                return NodeState.Success;
+
+			if (result == NodeState.Success)
+			{
+				_repeatCount++;
+
+				if (MaxRepeats > 0 && _repeatCount >= MaxRepeats)
+				{
+					_repeatCount = 0;
+					return result;
+				}
+				else
+				{
+					return NodeState.Running;
+				}
+			}
+			return NodeState.Running;
+		}
+	}
+}


### PR DESCRIPTION
The common name for a node which repeats its child until it fails is **Repeat Until Fail**, however, Repeater Until Failure matches the node name Repeater better. This PR implements the [functionality](https://www.researchgate.net/figure/The-repeat-until-failure-decorator_fig3_318679182) of Repeat Until Fail in BurtTree.

Furthermore, improvements have been made to the AddCustomType() registration to prevent a new custom type from being missed on RemoveCustomType() cleanup. 

/ **AgarthaSeekerDevelopmentTeam**